### PR TITLE
Use duration in creating TimeRange if seekableEnd is not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -271,12 +271,14 @@ export class FlashlsHandler {
   seekable() {
     const seekableStart = this.tech_.el_.vjs_getProperty('seekableStart');
     const seekableEnd = this.tech_.el_.vjs_getProperty('seekableEnd');
+    const duration = this.tech_.el_.vjs_getProperty('duration');
 
-    if (seekableEnd === 0) {
-      return videojs.createTimeRange();
+    if (seekableEnd !== 0 && duration !== 0) {
+      return videojs.createTimeRange(seekableStart, seekableEnd);
+    } else if (duration !== 0) {
+      return videojs.createTimeRange(0, duration);
     }
-
-    return videojs.createTimeRange(seekableStart, seekableEnd);
+    return videojs.createTimeRange();
   }
 
   media_() {


### PR DESCRIPTION
One of the solutions for [the issue currentTime not working  in `videojs-flash`](https://github.com/videojs/videojs-flash/issues/66)
In HLS we may get `seekableEnd` and `seekableStart` to get the valid TimeRange
But sometimes we cannot get `seekableStart` and  `seekableEnd`， so keep the default `duration` in `seekable()`.