### PR TITLE
fix: Use the same inBandMetadataTrackDispatchType that is exposed by mux.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "preversion": "npm test",
     "version": "is-prerelease || npm run update-changelog && git add CHANGELOG.md",
     "watch": "npm-run-all -p watch:*",
-    "watch:css": "npm run build:css -- -w",
     "watch:js": "npm run build:js -- -w",
     "prepublishOnly": "npm run build && vjsverify"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -411,7 +411,9 @@ export class FlashlsHandler {
         label: 'Timed Metadata'
       }, false).track;
 
-      this.metadataTrack_.inBandMetadataTrackDispatchType = '';
+      // This value is equivalent to (0x15).toString(16) which comes from mux.js:
+      // https://github.com/videojs/mux.js/blob/668954f45f1dbe3742a4c8b7750d5458075d34db/lib/m2ts/stream-types.js#L6
+      this.metadataTrack_.inBandMetadataTrackDispatchType = '15';
     }
 
     removeOldCues(this.tech_.buffered(), this.metadataTrack_);


### PR DESCRIPTION
We were not seeing in-band metadata tracks working in IE11/Win7, where we use this library. It seems like the cause is that this library was providing an `inBandMetadataTrackDispatchType` of `''`, which caused us to ignore this metadata track.

The mux.js library sets this value to the equivalent of `(0x15).toString(16)`, which is `"15"`.

I have verified that this change fixes the issue in that our code now acknowledges the in-band metadata track correctly.